### PR TITLE
Set DB_HBA_TRUST_NETS dynamically to support non-default networks

### DIFF
--- a/etc/cont-init.d/21-hba-conf
+++ b/etc/cont-init.d/21-hba-conf
@@ -12,7 +12,7 @@ if ! test -d $DB_PATH -a $DB_PATH/pg_hba.conf; then
 fi
 
 if [ -z "$DB_HBA_TRUST_NETS" ]; then
-  DB_HBA_TRUST_NETS="172.17.0.0/16"
+  DB_HBA_TRUST_NETS="$(route | grep "*" | cut -d " " -f 1)/16"
 fi
 
 if [ "$DB_HBA_TRUST_NETS" != "none" ]; then


### PR DESCRIPTION
Not sure if there's a more preferred way to accomplish this, but it works in my own testing and doesn't require any additional packages to be installed.

Closes #2